### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,18 +20,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           fetch-depth: 0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Linting code
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.53


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/codeql-analysis.yml:23` `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5`
- `.github/workflows/codeql-analysis.yml:29` `github/codeql-action/init@v1` -> `github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144`
- `.github/workflows/codeql-analysis.yml:34` `github/codeql-action/autobuild@v1` -> `github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144`
- `.github/workflows/codeql-analysis.yml:37` `github/codeql-action/analyze@v1` -> `github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144`
- `.github/workflows/lint_test.yml:20` `actions/setup-go@v3` -> `actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495`
- `.github/workflows/lint_test.yml:24` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/lint_test.yml:26` `golangci/golangci-lint-action@v3` -> `golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc`