### PR TITLE
security: [sc-19289] raise the go directive to 1.25.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronicleprotocol/infestor
 
-go 1.25.0
+go 1.25.13
 
 require (
 	github.com/defiweb/go-eth v0.4.3


### PR DESCRIPTION
Raises the `go` directive from **1.25.0 to 1.25.13**. One line, no dependency changes.

## Why

Earlier in the sc-19289 sweep this repo's directive was set to `1.25.0`, because that is the minimum `golang.org/x/crypto` v0.52.0 requires. That was the wrong choice, and this corrects it.

Go 1.25.0 is itself affected by two standard-library advisories:

| Advisory | Package | Fixed in |
|---|---|---|
| `GO-2026-5856` | `crypto/tls` — Encrypted Client Hello privacy leak | 1.25.12 |
| `GO-2026-6091` | `html/template` — Javascript regexp context tracking | 1.25.13 |

Where CI resolves its toolchain from `go.mod`, the directive decides which Go actually builds and ships. Pinning the bare minimum satisfied the dependency while leaving the build on a stdlib with two known advisories.

1.25.13 is the lowest patch clearing both, so this stays inside the 1.25 line rather than jumping to 1.26.

## How this surfaced

Neither advisory appears in Dependabot, because they are standard-library issues rather than module ones. They only became visible because `poa-access-server` runs `govulncheck`, which is the one repo in the fleet that does. Every other repo is equally affected and silent about it.

## Verification

`go build ./...` passes. `go.sum` is unchanged, since a directive bump alters no dependencies.

Any pre-existing test failures in this repo are unchanged by this PR and were documented when its x/crypto bump landed.

Refs sc-19289.
